### PR TITLE
py3 compatibility

### DIFF
--- a/cobertura_clover_transform/converter.py
+++ b/cobertura_clover_transform/converter.py
@@ -24,6 +24,6 @@ if __name__ == '__main__':
 
     if args.output:
         with open(args.output, 'w') as out:
-            out.write(converted)
+            out.write(converted.decode())
     else:
         print(converted)


### PR DESCRIPTION
ET.tostring() returns bytes in py3, which can't be written to non-binary file. decode() solves the problem
