### PR TITLE
Fixing incorrect import problem

### DIFF
--- a/cobertura_clover_transform/__init__.py
+++ b/cobertura_clover_transform/__init__.py
@@ -1,1 +1,1 @@
-from converter import convert
+from .converter import convert


### PR DESCRIPTION
Fixes errors like:

```
Traceback (most recent call last):
  File "convert_coverage.py", line 5, in <module>
    from cobertura_clover_transform import converter
  File "/~/src/.tox/py276/lib/python3.4/site-packages/cobertura_clover_transform/__init__.py", line 1, in <module>
    from converter import convert
ImportError: No module named 'converter'
```
