### PR TITLE
feat: add console script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,10 @@ setup(
     author_email='cwacek@gmail.com',
     url='http://github.com/cwacek/cobertura-clover-transform',
     license='MIT',
-    keywords='cobertura coverage test clover xml'
+    keywords='cobertura coverage test clover xml',
+    entry_points = {
+        'console_scripts': [
+            'cobertura-clover-transform = cobertura_clover_transform.converter'
+        ]
+    }
 )


### PR DESCRIPTION
When using `pip install -q -U cobertura-clover-transform` in a virtualenv environment within Bamboo, I keep on getting `bad interpreter: No such file or directory` when using `python -m cobertura_clover_transform.converter`.
This PR adds a console script shortcut, that will allow one to call

``` console
cobertura-clover-transform <file>
```

after installing this package via pip.
